### PR TITLE
Allow the recolor plugin to use grayscale images

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,5 @@
 # svg-color-loader
-`svg-color-loader` is a webpack plugin for coloring flat svg icons at build time.
+`svg-color-loader` is a webpack plugin for coloring grayscale svg icons at build time.
 
 
 
@@ -7,7 +7,7 @@
 
 We built this tool because we wanted to use [Sass](https://sass-lang.com/) color variables for svg icons. Additionally, we wanted to use the same icon with varying colors without modifying or duplicating the svg images.
 
-
+When the tool processes an svg, it coverts black elements to your specified color, grey elements to an appropriate shade of your color and leaves white elements alone.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Recolors svg icons as part of webpack build",
   "main": "index.js",
   "dependencies": {
+    "chroma-js": "^2.1.0",
     "svgo": "^1.3.2"
   },
   "author": "HighGear",

--- a/util.js
+++ b/util.js
@@ -1,12 +1,3 @@
-function toHex(value) {
-	var hex = parseInt(value).toString(16);
-	return hex.length === 1 ? "0" + hex : hex;
-}
-
-function rgbToHex(r, g, b) {
-	return "#" + toHex(r) + toHex(g) + toHex(b);
-}
-
 function parseQueryString(queryString) {
 	var parts = queryString
 		.substring(1) //remove leading ?
@@ -21,6 +12,5 @@ function parseQueryString(queryString) {
 }
 
 module.exports = {
-    rgbToHex,
     parseQueryString,
 }


### PR DESCRIPTION
This means "cutout" type images where a white shape is placed against a
black one now works correctly.

For example:

```
|------------------------------|
|                              |
|       (black)                |
|                              |
|    |---------------|         |
|    |               |         |
|    |  (white)      |         |
|    |               |         |
|    |---------------|         |
|------------------------------|
```

Now produces a colored box with a white hole instead of just a color
square.